### PR TITLE
Fixes React.PropTypes deprecation warning message

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "mocha": "^2.4.5",
     "postcss-loader": "^1.2.2",
     "prompt": "^0.2.14",
+    "prop-types": "^15.5.10",
     "react": "^15.4.2",
     "react-addons-test-utils": "^15.0.1",
     "react-dom": "^15.4.2",

--- a/src/FocusTrap.js
+++ b/src/FocusTrap.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 export const FocusTrap = ({ component: Component, children, ...props }) =>
   <Component tabIndex="-1" {...props}>
@@ -6,10 +7,10 @@ export const FocusTrap = ({ component: Component, children, ...props }) =>
   </Component>
 
 FocusTrap.propTypes = {
-  onFocus: React.PropTypes.func,
-  onBlur: React.PropTypes.func,
-  component: React.PropTypes.any,
-  children: React.PropTypes.node,
+  onFocus: PropTypes.func,
+  onBlur: PropTypes.func,
+  component: PropTypes.any,
+  children: PropTypes.node,
 }
 
 FocusTrap.defaultProps = {

--- a/src/HotKeys.js
+++ b/src/HotKeys.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import { findDOMNode } from 'react-dom'
 import Mousetrap from 'mousetrap'
 
@@ -17,25 +18,6 @@ function getSequencesFromMap(hotKeyMap, hotKeyName) {
 }
 
 export class HotKeys extends Component {
-
-  static propTypes = {
-    active: React.PropTypes.bool,
-    children: React.PropTypes.node,
-    onFocus: React.PropTypes.func,
-    onBlur: React.PropTypes.func,
-    keyMap: React.PropTypes.object,
-    handlers: React.PropTypes.object,
-  }
-
-  static contextTypes = {
-    hotKeyParent: React.PropTypes.any,
-    hotKeyMap: React.PropTypes.object,
-  }
-
-  static childContextTypes = {
-    hotKeyParent: React.PropTypes.any,
-    hotKeyMap: React.PropTypes.object,
-  }
 
   getChildContext() {
     return {
@@ -141,4 +123,23 @@ export class HotKeys extends Component {
       </FocusTrap>
     )
   }
+}
+
+HotKeys.propTypes = {
+  active: PropTypes.bool,
+  children: PropTypes.node,
+  onFocus: PropTypes.func,
+  onBlur: PropTypes.func,
+  keyMap: PropTypes.object,
+  handlers: PropTypes.object,
+}
+
+HotKeys.contextTypes = {
+  hotKeyParent: PropTypes.any,
+  hotKeyMap: PropTypes.object,
+}
+
+HotKeys.childContextTypes = {
+  hotKeyParent: PropTypes.any,
+  hotKeyMap: PropTypes.object,
 }


### PR DESCRIPTION
Hi @ruanyl !

First of all, thanks for doing this forked react-shortcut lib, as it handles perfectly the bubbling up of events, which is just what we needed 👍 

Using your lib, saw the following warning:

> Accessing PropTypes via the main React package is deprecated, and will be removed in  React v16.0. Use the latest available v15.* prop-types package from npm instead. For info on usage, compatibility, migration and more, see https://fb.me/prop-types-docs

This PR should fix it

